### PR TITLE
Correct minimum Emacs version

### DIFF
--- a/commenter.el
+++ b/commenter.el
@@ -5,7 +5,7 @@
 ;; Author: Yuta Yamada <cokesboy"at"gmail.com>
 ;; URL: https://github.com/yuutayamada/commenter
 ;; Version: 0.5.0
-;; Package-Requires: ((emacs "24.3") (let-alist "1.0.1"))
+;; Package-Requires: ((emacs "24.4") (let-alist "1.0.1"))
 ;; Keywords: comment
 
 ;;; License:


### PR DESCRIPTION
'nadvice' was introduced at Emacs 24.4.
